### PR TITLE
Proposed method of handling Caps from a client

### DIFF
--- a/lib/capabilities.go
+++ b/lib/capabilities.go
@@ -1,0 +1,80 @@
+package ircbnc
+
+import (
+	"strings"
+
+	"github.com/goshuirc/irc-go/ircmsg"
+)
+
+type CapManager struct {
+	Supported            map[string]string
+	FnsMessageToClient   []func(*Listener, *ircmsg.IrcMessage) bool
+	FnsMessageFromClient []func(*Listener, *ircmsg.IrcMessage) bool
+}
+
+var Capabilities CapManager
+
+func init() {
+	Capabilities = CapManager{
+		Supported: make(map[string]string),
+	}
+	CapAwayNotify(&Capabilities)
+}
+
+// AsString returns a list ready to send to the client of all our CAPs
+func (caps *CapManager) AsString() string {
+	capList := " "
+
+	for cap, val := range caps.Supported {
+		capList += cap
+		if val != "" {
+			capList += "=" + val
+		}
+		capList += " "
+	}
+
+	return strings.Trim(capList, " ")
+}
+
+// MessageToClient runs messages through any CAPs before being sent to the client
+func (caps *CapManager) MessageToClient(listener *Listener, message *ircmsg.IrcMessage) bool {
+	for _, fn := range caps.FnsMessageToClient {
+		shouldHalt := fn(listener, message)
+		if shouldHalt {
+			return true
+		}
+	}
+
+	return false
+}
+
+// MessageFromClient runs messages received from a client through any CAPs
+func (caps *CapManager) MessageFromClient(listener *Listener, message *ircmsg.IrcMessage) bool {
+	for _, fn := range caps.FnsMessageFromClient {
+		shouldHalt := fn(listener, message)
+		if shouldHalt {
+			return true
+		}
+	}
+
+	return false
+}
+
+/**
+ * CAP: away-notify
+ */
+func CapAwayNotify(caps *CapManager) {
+	name := "away-notify"
+	caps.Supported[name] = ""
+
+	caps.FnsMessageToClient = append(
+		caps.FnsMessageToClient,
+		func(listener *Listener, message *ircmsg.IrcMessage) bool {
+			if message.Command == "AWAY" && !listener.IsCapEnabled(name) {
+				return true
+			}
+
+			return false
+		},
+	)
+}

--- a/lib/capabilities.go
+++ b/lib/capabilities.go
@@ -26,8 +26,8 @@ func init() {
 	CapServerTime(&Capabilities)
 }
 
-// AsString returns a list ready to send to the client of all our CAPs
-func (caps *CapManager) AsString() string {
+// SupportedString returns a list ready to send to the client of all our CAPs
+func (caps *CapManager) SupportedString() string {
 	capList := " "
 
 	for cap, val := range caps.Supported {
@@ -39,6 +39,20 @@ func (caps *CapManager) AsString() string {
 	}
 
 	return strings.Trim(capList, " ")
+}
+
+// FilterSupported filters the supported CAPs by the requested
+func (caps *CapManager) FilterSupported(requested []string) map[string]string {
+	matched := make(map[string]string)
+
+	for _, cap := range requested {
+		capVal, isAvailable := Capabilities.Supported[cap]
+		if isAvailable {
+			matched[cap] = capVal
+		}
+	}
+
+	return matched
 }
 
 // MessageToClient runs messages through any CAPs before being sent to the client

--- a/lib/commandhandlers.go
+++ b/lib/commandhandlers.go
@@ -99,26 +99,16 @@ func loadClientCommands() {
 			// We're starting CAP negotiations so don't complete regisration until then
 			listener.regLocks.Set("cap", false)
 
-			availableCaps := map[string]string{
-				"account-notify": "",
-			}
-
 			command := getParam(&msg, 0)
 			if command == "LS" {
-				capList := ""
-				for cap, val := range availableCaps {
-					capList += cap
-					if val != "" {
-						capList += "=" + val
-					}
-					capList += " "
-				}
+				capList := Capabilities.AsString()
 				listener.Send(nil, "", "CAP", "*", "LS", capList)
+
 			} else if command == "REQ" {
 				caps := strings.Split(getParam(&msg, 1), " ")
 				acked := []string{}
 				for _, cap := range caps {
-					capVal, isAvailable := availableCaps[cap]
+					capVal, isAvailable := Capabilities.Supported[cap]
 					if isAvailable {
 						listener.Caps[cap] = capVal
 						acked = append(acked, cap)
@@ -126,6 +116,7 @@ func loadClientCommands() {
 				}
 
 				listener.Send(nil, "", "CAP", "*", "ACK", strings.Join(acked, " "))
+
 			} else if command == "END" {
 				listener.regLocks.Set("cap", true)
 			}

--- a/lib/listener.go
+++ b/lib/listener.go
@@ -58,6 +58,7 @@ type Listener struct {
 	Manager          *Manager
 	ConnectTime      time.Time
 	Caps             map[string]string
+	TagsEnabled      bool
 	ClientNick       string
 	Source           string
 	Registered       bool
@@ -216,7 +217,12 @@ func (listener *Listener) processIncomingLine(line string) {
 
 // Send sends an IRC line to the listener.
 func (listener *Listener) Send(tags *map[string]ircmsg.TagValue, prefix string, command string, params ...string) error {
-	message := ircmsg.MakeMessage(tags, prefix, command, params...)
+	var message ircmsg.IrcMessage
+	if listener.TagsEnabled {
+		message = ircmsg.MakeMessage(tags, prefix, command, params...)
+	} else {
+		message = ircmsg.MakeMessage(nil, prefix, command, params...)
+	}
 
 	shouldHalt := Capabilities.MessageToClient(listener, &message)
 	if shouldHalt {


### PR DESCRIPTION
We currently have bnc<>ircd caps, and now this handles client<>ircd caps. Any capabilities can be added to the BNC core via capabilities.go in a single function. `away-notify` example is included.

This runs any messages sent to or from a client through any cap handlers that have registered themselves to process them. In case of the `away-notify` example, if the client does not support `away-notify` but the bnc<>ircd does, then `AWAY` messages to the client will be dropped. Cap handlers also have the opportunity to modify the message if needed.

Questions:
* Are there any caps that would need more involvement than hijacking/modifying sent and received messages from the client?