### PR TITLE
Utilize ParseArgs in favor or deprecated Parse

### DIFF
--- a/bnc.go
+++ b/bnc.go
@@ -33,7 +33,7 @@ Options:
 	-h --help          Show this screen.
 	--version          Show version.`
 
-	arguments, _ := docopt.Parse(usage, nil, true, ircbnc.SemVer, false)
+	arguments, _ := docopt.ParseArgs(usage, nil, ircbnc.SemVer)
 
 	configfile := arguments["--conf"].(string)
 	config, err := ircbnc.LoadConfig(configfile)


### PR DESCRIPTION
No loss in functionality is apparent.